### PR TITLE
fix: override semver dependency to patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6453,7 +6453,7 @@
         "node-fetch": "^2.6.0",
         "parse-png": "^2.1.0",
         "resolve-from": "^5.0.0",
-        "semver": "7.3.2",
+        "semver": "^7.5.4",
         "tempy": "0.3.0"
       }
     },
@@ -6546,9 +6546,9 @@
       }
     },
     "node_modules/expo-pwa/node_modules/semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
   "devDependencies": {
     "@babel/core": "^7.28.4"
   },
+  "overrides": {
+    "semver": "^7.5.4",
+    "@expo/image-utils>semver": "^7.5.4"
+  },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add npm override to force semver >=7.5.4
- update lockfile for expo-pwa to use semver 7.5.4

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4883105a483338bffffe9573747b1